### PR TITLE
Add 1.17 mobs' heads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,14 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.github.slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>RC-27</version>
+            <version>RC-28</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/io/github/thebusybiscuit/extraheads/ExtraHeads.java
+++ b/src/main/java/io/github/thebusybiscuit/extraheads/ExtraHeads.java
@@ -104,7 +104,13 @@ public class ExtraHeads extends JavaPlugin implements SlimefunAddon {
             registerHead("Zombified Piglin Head", EntityType.ZOMBIFIED_PIGLIN, "e935842af769380f78e8b8a88d1ea6ca2807c1e5693c2cf797456620833e936f");
             registerHead("Strider", EntityType.STRIDER, "18a9adf780ec7dd4625c9c0779052e6a15a451866623511e4c82e9655714b3c1");
         }
-        
+
+        if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
+            registerHead("Axolotl Head", EntityType.AXOLOTL, "5c138f401c67fc2e1e387d9c90a9691772ee486e8ddbf2ed375fc8348746f936");
+            registerHead("Glow Squid Head", EntityType.GLOW_SQUID, "57327ee11812b764c7ade70b282cce4c58e635b2015244081d1490543da7280e");
+            registerHead("Goat Head", EntityType.GOAT, "457a0d538fa08a7affe312903468861720f9fa34e86d44b89dcec5639265f03");
+        }
+
         cfg.save();
 
         new HeadListener(this);


### PR DESCRIPTION
Add 1.17 mobs' heads: Axolotl, Glow squid, and Goat.
![image](https://user-images.githubusercontent.com/7105953/138585768-3094535e-ea02-42cd-bf96-14a0a71f6f60.png)
